### PR TITLE
Formatting Tweaks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,34 @@
-# convolutional_encoder_viterbi_decoder
+# Convolutional Encoder - Viterbi Decoder
+
 A convolutional encoder and a viterbi decoder for all code rates based on puncturing pattern.
 
-fec_tests.c is used to simulate different test cases.
-steps to initiate and run an fec:
-1. give the neccessary information for the init_fec() function to initate an fec like constarint length, trellis polynomials, 
-   n_repeats for repeated codes(0 if not a repeated code), puncturing pattern([1,1,1,1] if puncturing is not needed), fulltail biting enable/disable
-2. print_fec() prints the current configured fec data.
-3. encode() function encodes the input binary(bits) stream using provided fec type.
-4. print_array() function prints the data in an array. used to monitor the arrays at all the stages.(ofcourse one can use gdb).
+`fec_tests.c` is used to simulate different test cases.
 
-how to build and run?
--> Go to build directory if it is there. if not, create one as follows in the terminal
--> cd build
--> cmake ..
--> make
--> ./fec_test.exe
+Steps to initiate and run an FEC (Forward Error Correction):
+
+1. Give the neccessary information for the `init_fec()` function to initate an fec like constraint length, trellis polynomials, 
+   n_repeats for repeated codes(0 if not a repeated code), puncturing pattern, full tail-biting enabled/disabled.
+   - Provide [1,1,1,1] as puncturing pattern if puncturing is not needed.
+3. `print_fec()` prints the current configured FEC data.
+4. `encode()` function encodes the input binary(bits) stream using provided FEC type.
+5. `print_array()` function prints the data in an array. This is used to monitor the arrays at all the stages. (of course, one can use `gdb`).
+
+## Building and Running
+
+This project uses `cmake`. If not installed already, install using your OS's package manager. `sudo apt install cmake` on Ubuntu, for instance.
+
+```
+#### build ###
+mkdir build    # only required for the first time
+cd build
+cmake ..
+make
+
+###  run (on linux) ###
+./fec_test
+
+###  run (on windows) ###
+./fec_test.exe
+
+```
+


### PR DESCRIPTION
* more adherence to markdown/commonmark 
    - function names, filenames wrapped in backticks
    - subsection for build and run
    - build instructions as codeblock.

* minor copy edits (hint about cmake, heading tweaked, ...)